### PR TITLE
add adapter in two places per layer

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -57,6 +57,9 @@ class BertAdaptedSelfOutput(nn.Module):
 def adapt_bert_self_output(config: AdapterConfig):
     return lambda self_output: BertAdaptedSelfOutput(self_output, config=config)
 
+def adapt_bert_output(config: AdapterConfig):
+    return lambda self_output: BertAdaptedSelfOutput(self_output, config=config)
+
 
 def add_adapters(bert_model: BertModel,
                  config: AdapterConfig) -> BertModel:
@@ -64,6 +67,8 @@ def add_adapters(bert_model: BertModel,
     for i in range(len(bert_model.encoder.layer)):
         bert_encoder.layer[i].attention.output = adapt_bert_self_output(config)(
             bert_encoder.layer[i].attention.output)
+        bert_encoder.layer[i].output = adapt_bert_output(config)(
+            bert_encoder.layer[i].output)
 
     # Freeze all parameters
     for param in bert_model.parameters():


### PR DESCRIPTION
In the [original paper](https://arxiv.org/pdf/1902.00751.pdf) (fig2) "We add the adapter module twice to each Transformer layer". This change should do that.

Also see [bert-on-stilts](https://github.com/zphang/bert_on_stilts/blob/master/pytorch_pretrained_bert/modeling.py#L388) where they implement it in two places on the huggingface library.

Tangential question: patching the model in this way makes it hard to save and load, do you know any workaround that doesn't result rewriting modeling_bert.py?

Thanks for sharing this repo!